### PR TITLE
Setup eslint, prettier, and tailwind

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+# Ignore artifacts:
+build
+coverage
+node_modules
+
+# Ignore all HTML files:
+*.html
+
+# Ignore specific files in the root directory:
+/public/vercel.svg
+/public/window.svg

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 80,
+  "tabWidth": 2
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends("next/core-web-vitals", "next/typescript", "prettier"),
 ];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "prettier": "prettier --write ."
   },
   "dependencies": {
     "next": "15.2.0",
@@ -23,6 +24,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.0",
     "tailwindcss": "^4.0.9",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prettier": "^3.0.0"
   }
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,7 @@
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},
+    tailwindcss: {},
   },
 };
 export default config;


### PR DESCRIPTION
Configure eslint, prettier, and tailwind style for both production and development environments.

* **package.json**
  - Add `prettier` to `devDependencies`.
  - Add `prettier` script to `scripts`.

* **eslint.config.mjs**
  - Add `prettier` to `extends` array.

* **postcss.config.mjs**
  - Add `tailwindcss` to `plugins`.

* **.prettierrc**
  - Add configuration for `prettier`.

* **.prettierignore**
  - Add ignore patterns for `prettier`.

