### PR TITLE
Fix TS2307 error by exporting logger module

### DIFF
--- a/app/ErrorBoundary.tsx
+++ b/app/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
-import logger from '../logger';
+import { logger } from '../next.config';
 
 interface Props {
   children: ReactNode;

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,4 +24,5 @@ const nextConfig: NextConfig = {
   /* config options here */
 };
 
+export { logger };
 export default nextConfig;


### PR DESCRIPTION
Fix the TS2307 error by correctly importing the `logger` module in `app/ErrorBoundary.tsx`.

* **Export `logger` module**: Export the `logger` module from `next.config.ts`.
* **Import `logger` module**: Import the `logger` module from `next.config` in `app/ErrorBoundary.tsx`.

