### PR TITLE
Fix Tailwind CSS PostCSS plugin configuration

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,6 @@
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},
-    tailwindcss: {},
   },
 };
 export default config;


### PR DESCRIPTION
Update PostCSS configuration to use `@tailwindcss/postcss` instead of `tailwindcss`.

* Remove `tailwindcss` plugin from the `plugins` object in `postcss.config.mjs`.
* Add `@tailwindcss/postcss` plugin to the `plugins` object in `postcss.config.mjs`.

