### PR TITLE
Fix types in page.tsx and CSS error

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -83,7 +83,6 @@
 
 @layer base {
   * {
-    @apply border-border;
   }
   body {
     @apply bg-background text-foreground;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,14 @@ const posts = [
   },
 ];
 
-const Post = ({ title, excerpt, author, date }) => (
+interface PostProps {
+  title: string;
+  excerpt: string;
+  author: string;
+  date: string;
+}
+
+const Post = ({ title, excerpt, author, date }: PostProps) => (
   <div className="post">
     <h2>{title}</h2>
     <p>{excerpt}</p>


### PR DESCRIPTION
Add explicit types for Post component props and remove invalid Tailwind CSS utility class.

* **TypeScript Changes:**
  - Add `PostProps` interface in `app/page.tsx` to define explicit types for `title`, `excerpt`, `author`, and `date` as `string`.
  - Update `Post` component to use `PostProps` interface for its props.

* **CSS Changes:**
  - Remove `@apply border-border` line from `app/globals.css` to fix the error caused by the unknown utility class.

