### PR TITLE
Fix Tailwind CSS configuration to recognize bg-background utility class

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "tailwindcss";
 import animate from "tailwindcss-animate";
+import forms from "@tailwindcss/forms"; // Pe05e
 
 const config: Config = {
     darkMode: 'class',
@@ -7,6 +8,7 @@ const config: Config = {
         "./pages/**/*.{js,ts,jsx,tsx,mdx}",
         "./components/**/*.{js,ts,jsx,tsx,mdx}",
         "./app/**/*.{js,ts,jsx,tsx,mdx}",
+        "./app/globals.css", // P3c9f
     ],
     theme: {
         container: {
@@ -103,7 +105,7 @@ const config: Config = {
             },
         }
     },
-    plugins: [animate],
+    plugins: [animate, forms], // Pe05e
 };
 
 export default config;


### PR DESCRIPTION
Update `tailwind.config.ts` to fix the "Cannot apply unknown utility class: bg-background" error.

* **Content Array**: Add `./app/globals.css` to the `content` array to ensure Tailwind processes it.
* **Plugins Array**: Add `@tailwindcss/forms` to the `plugins` array to include all necessary plugins.

