### PR TITLE
Fix unknown utility class error in Tailwind CSS

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -62,7 +62,8 @@ const config: Config = {
                     '3': 'hsl(var(--chart-3))',
                     '4': 'hsl(var(--chart-4))',
                     '5': 'hsl(var(--chart-5))'
-                }
+                },
+                'bg-background': 'hsl(var(--background))' // P4053
             },
             borderRadius: {
                 lg: 'var(--radius)',


### PR DESCRIPTION
Add `bg-background` utility class to Tailwind CSS configuration.

* Add `bg-background` utility class to the `extend.colors` section in `tailwind.config.ts` with the value `hsl(var(--background))`.

