### PR TITLE
Fix TS2322: Type number is not assignable to type string

### DIFF
--- a/types/tag.ts
+++ b/types/tag.ts
@@ -1,5 +1,5 @@
 export interface Tag {
-    id: string;
+    id: number;
     name: string;
     description?: string;
     image_url?: string;


### PR DESCRIPTION
Change the type of the `id` property in the `Tag` interface from `string` to `number`.

* Update `types/tag.ts` to reflect the new type for the `id` property.
