### PR TITLE
Fix tag type incompatibility

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import ErrorBoundary from "./ErrorBoundary";
 
 import React from "react";
 import { Post } from '@/types/post';
-import { Tag } from '@/app/page';
+import { Tag } from '@/types/tag';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ interface Post {
 }
 
 export interface Tag {
-  id: string;
+  id: number;
   name: string;
   description?: string;
   image_url?: string;
@@ -113,21 +113,21 @@ export default function Home() {
       {/* Sidebar */}
       <Sidebar className="mt-8" posts={posts} tags={[
         {
-          id: "1", name: 'technology',
+          id: 1, name: 'technology',
           created_at: '',
           tenant_id: '',
           image_url: "",
           description: ""
         },
         {
-          id: "2", name: 'programming',
+          id: 2, name: 'programming',
           created_at: '',
           tenant_id: '',
           image_url: "",
           description: ""
         },
         {
-          id: "3", name: 'travel',
+          id: 3, name: 'travel',
           created_at: '',
           tenant_id: '',
           image_url: "",
@@ -138,21 +138,21 @@ export default function Home() {
       {/* Footer */}
       <Footer className="text-center mt-8" posts={posts} tags={[
         {
-          id: "1", name: 'technology',
+          id: 1, name: 'technology',
           created_at: '',
           tenant_id: '',
           image_url: "",
           description: ""
         },
         {
-          id: "2", name: 'programming',
+          id: 2, name: 'programming',
           created_at: '',
           tenant_id: '',
           image_url: "",
           description: ""
         },
         {
-          id: "3", name: 'travel',
+          id: 3, name: 'travel',
           created_at: '',
           tenant_id: '',
           image_url: "",


### PR DESCRIPTION
Align `Tag` interface `id` type between `app/page.tsx` and `types/tag.ts`.

* Change `Tag` interface `id` type from `string` to `number` in `app/page.tsx`.
* Update `id` values in `app/page.tsx` to be numbers instead of strings.
* Import `Tag` from `types/tag` instead of `app/page` in `app/layout.tsx`.

