### PR TITLE
Fix TypeScript errors in page.tsx

### DIFF
--- a/types/post.ts
+++ b/types/post.ts
@@ -32,5 +32,5 @@ export interface Post {
     tipp: Tipp;
     author: string;
     date: string;
-    tags: string;
+    tags: string[];
 }


### PR DESCRIPTION
Change the `tags` property type from `string` to `string[]` in `types/post.ts`.

